### PR TITLE
Feat: Add Formspree Contact Form

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,10 +188,10 @@
                         Message on WhatsApp
                     </a>
                 </div>
-                <!-- IMPORTANT: Replace YOUR_FORMSPREE_ENDPOINT with your actual Formspree endpoint -->
-                <form id="contact-form" action="https://formspree.io/f/YOUR_FORMSPREE_ENDPOINT" method="POST">
+                <form id="contact-form" action="https://formspree.io/f/xrbawaqd" method="POST">
+                    <input type="hidden" name="_subject" value="New Inquiry from JyotishGuru Website">
                     <input type="text" name="name" placeholder="Your Name" required>
-                    <input type="email" name="email" placeholder="Your Email" required>
+                    <input type="email" name="_replyto" placeholder="Your Email" required>
                     <textarea name="message" placeholder="Your Message" rows="5" required></textarea>
                     <button type="submit" class="cta-button">Send Message</button>
                 </form>


### PR DESCRIPTION
This commit integrates a functional Formspree contact form into the website.

- Updates the form's `action` attribute to the correct Formspree endpoint.
- Changes the email input's `name` attribute to `_replyto` to set the reply-to address for submissions.
- Adds a hidden `_subject` input to provide a default subject line for new inquiries.