### PR TITLE
fix: Resolve critical bug causing content to be hidden on load

### DIFF
--- a/script.js
+++ b/script.js
@@ -12,6 +12,11 @@ document.addEventListener('DOMContentLoaded', () => {
         once: true, // whether animation should happen only once - while scrolling down
     });
 
+    // Refresh AOS after all content (including images) has loaded to prevent elements being hidden
+    window.addEventListener('load', () => {
+        AOS.refresh();
+    });
+
     // --- HOROSCOPE FORM ---
     const horoscopeForm = document.getElementById('horoscope-form');
     const horoscopeResult = document.getElementById('horoscope-result');

--- a/style.css
+++ b/style.css
@@ -453,6 +453,25 @@ footer {
 /* ------------------- */
 /* Utility Classes     */
 /* ------------------- */
+/*
+  AOS Bug Fix: Ensure content is visible on page load.
+  This rule makes elements visible by default. The `aos-init` class is added
+  by the AOS JavaScript library, so the second rule only applies the "hidden"
+  animation state once the library is ready.
+*/
+[data-aos] {
+  opacity: 1 !important;
+  transform: none !important;
+}
+.aos-init .aos-animate {
+  opacity: 1 !important;
+  transform: none !important;
+}
+.aos-init [data-aos]:not(.aos-animate) {
+    opacity: 0 !important;
+}
+
+
 .notification {
     position: fixed;
     top: 20px;


### PR DESCRIPTION
This commit fixes a critical bug where content sections below the hero were not visible on initial page load. The issue was caused by the Animate On Scroll (AOS) library hiding elements by default without correctly revealing those already in the viewport.

The fix involves a robust CSS override that ensures all `[data-aos]` elements are visible by default. The "hidden" animation state is now only applied after the AOS JavaScript has successfully initialized, guaranteeing content visibility even if the script encounters issues.

This change ensures a seamless user experience and that all page content is immediately accessible to visitors upon arrival.